### PR TITLE
work around alloc bug

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -1076,7 +1076,7 @@ func (stmt *mysqlStmt) writeExecutePacket(args []driver.Value) error {
 				var b = a[:0]
 
 				if v.IsZero() {
-					b = append(b, "0000-00-00"...)
+					b = append(b, '0', '0', '0', '0', '-', '0', '0', '-', '0', '0')
 				} else {
 					b = v.In(mc.cfg.Loc).AppendFormat(b, timeFormat)
 				}


### PR DESCRIPTION
Before:
```asm
	0x0fca 04042 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	MOVQ	AX, (SP)
	0x0fce 04046 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	LEAQ	go.string."0000-00-00"(SB), AX
	0x0fd5 04053 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	MOVQ	AX, 8(SP)
	0x0fda 04058 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	MOVQ	$10, 16(SP)
	0x0fe3 04067 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	PCDATA	$0, $4
	0x0fe3 04067 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	CALL	runtime.memmove(SB)
	0x0fe8 04072 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	LEAQ	"".a+328(SP), AX
	0x0ff0 04080 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	MOVL	$10, CX
```
After:
```asm
	0x0fcc 04044 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	MOVQ	DX, "".a+328(SP)
	0x0fd4 04052 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	MOVW	$12336, "".a+336(SP)
	0x0fde 04062 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	LEAQ	"".a+328(SP), DX
	0x0fe6 04070 (/Users/achilleroussel/dev/src/github.com/segmentio/mysql/packets.go:1079)	MOVL	$10, R8
```